### PR TITLE
Upgrade to .NET Standard 2.0 for .NET 5-7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ app.config
 docs/api/*.yml
 docs/api/.manifest
 docs/_site
+
+# Logs from failed tests
+*.log

--- a/samples/Console/Console.csproj
+++ b/samples/Console/Console.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
  <ItemGroup>
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
     <ProjectReference Include="..\..\src\EULex\EULex.csproj" />
   </ItemGroup>
 

--- a/samples/Console/Program.cs
+++ b/samples/Console/Program.cs
@@ -31,7 +31,7 @@ namespace ConsoleSample
 {
     class MainClass
     {
-        public static void Main (string[] args)
+        public static void Main ()
         {
             MainAsync ().Wait ();
         }

--- a/src/EULex/EULex.csproj
+++ b/src/EULex/EULex.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <AssemblyVersion>0.4.0.0</AssemblyVersion>
-    <FileVersion>0.4.0.0</FileVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyVersion>0.5.0.0</AssemblyVersion>
+    <FileVersion>0.5.0.0</FileVersion>
     <PackageId>EULex</PackageId>
     <Description>Cross-platform, open source .NET library to retrieve legal data available on the EUR-Lex web site</Description>
-    <Version>0.4.0</Version>
+    <Version>0.5.0</Version>
     <Authors>Bertrand Lorentz</Authors>
     <Company />
     <Product>EULex.NET</Product>

--- a/src/EULex/EURLexWebService/Client.cs
+++ b/src/EULex/EURLexWebService/Client.cs
@@ -44,12 +44,12 @@ namespace EULex.EURLexWebService
         // "2 consecutive calls to EUR-Lex web service must not be performed within 500 ms"
         private static readonly TimeSpan MINIMUM_DELAY_MS = TimeSpan.FromMilliseconds(500);
 
-        private static TimeLimiter rate_limiter = TimeLimiter.GetFromMaxCountByInterval(1, MINIMUM_DELAY_MS);
+        private readonly static TimeLimiter rate_limiter = TimeLimiter.GetFromMaxCountByInterval(1, MINIMUM_DELAY_MS);
 
-        SoapClient soap_client;
-        string server_url;
-        string username;
-        string password;
+        readonly SoapClient soap_client;
+        readonly string server_url;
+        readonly string username;
+        readonly string password;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EULex.EURLexWebService.Client"/> class with the default

--- a/src/EULex/SimpleSOAPClient/Helpers/XmlHelpers.cs
+++ b/src/EULex/SimpleSOAPClient/Helpers/XmlHelpers.cs
@@ -78,7 +78,7 @@ namespace EULex.SimpleSOAPClient.Helpers
         /// <returns>The deserialized object</returns>
         public static T ToObject<T> (this string xml)
         {
-            if (string.IsNullOrWhiteSpace (xml)) return default (T);
+            if (string.IsNullOrWhiteSpace (xml)) return default;
 
             using (var textWriter = new StringReader (xml)) {
                 var result = (T)new XmlSerializer (typeof (T)).Deserialize (textWriter);
@@ -96,7 +96,7 @@ namespace EULex.SimpleSOAPClient.Helpers
         /// <returns>The deserialized object</returns>
         public static T ToObject<T> (this XElement xml)
         {
-            return xml == null ? default (T) : xml.ToString ().ToObject<T> ();
+            return xml == null ? default : xml.ToString ().ToObject<T> ();
         }
     }
 }

--- a/src/EULex/SimpleSOAPClient/SoapClient.cs
+++ b/src/EULex/SimpleSOAPClient/SoapClient.cs
@@ -66,9 +66,7 @@ namespace EULex.SimpleSOAPClient
         /// <param name="httpClient">The <see cref="HttpClient"/> to be used</param>
         public SoapClient (HttpClient httpClient)
         {
-            if (httpClient == null) throw new ArgumentNullException (nameof (httpClient));
-
-            HttpClient = httpClient;
+			HttpClient = httpClient ?? throw new ArgumentNullException (nameof (httpClient));
         }
 
         #endregion
@@ -103,7 +101,7 @@ namespace EULex.SimpleSOAPClient
         /// <param name="ct">The cancellation token</param>
         /// <returns>A task to be awaited for the result</returns>
         public virtual async Task<SoapEnvelope> SendAsync (
-            string url, SoapEnvelope requestEnvelope, CancellationToken ct = default (CancellationToken))
+            string url, SoapEnvelope requestEnvelope, CancellationToken ct = default)
         {
             if (RequestEnvelopeHandler != null) {
                 requestEnvelope = RequestEnvelopeHandler (url, requestEnvelope);

--- a/tests/IntegrationTests/EULex.IntegrationTests.csproj
+++ b/tests/IntegrationTests/EULex.IntegrationTests.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <RootNamespace>EULex.IntegrationTests</RootNamespace>
     <AssemblyName>EULex.IntegrationTests</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
     <ProjectReference Include="..\..\src\EULex\EULex.csproj" />
   </ItemGroup>
 

--- a/tests/IntegrationTests/ResultsListTests.cs
+++ b/tests/IntegrationTests/ResultsListTests.cs
@@ -33,7 +33,7 @@ namespace EULex.IntegrationTests
     {
         Client client;
         SearchRequest search_request;
-        int page_size = 20;
+        readonly int page_size = 20;
 
         [OneTimeSetUp]
         protected void SetUp ()

--- a/tests/IntegrationTests/TestUtils.cs
+++ b/tests/IntegrationTests/TestUtils.cs
@@ -50,13 +50,15 @@ namespace EULex.IntegrationTests
         {
             using (var client = GetClient ()) {
 
-                var request = new SearchRequest ();
-                request.ExpertQuery = query;
-                request.PageSize = page_size;
-                request.Page = page;
-                request.SearchLanguage = lang;
+				var request = new SearchRequest
+				{
+					ExpertQuery = query,
+					PageSize = page_size,
+					Page = page,
+					SearchLanguage = lang
+				};
 
-                var results = await client.DoQueryAsync (request);
+				var results = await client.DoQueryAsync (request);
                 return results;
             }
         }


### PR DESCRIPTION
Also takes advantage of some newer MS-recommended syntax, and adds a gitignore entry for failed test trace logs. Bumps version to 0.5.0.

Issue reference: #10 